### PR TITLE
update docker file and readme documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,6 @@ _site/
 .sass-cache/
 .jekyll-cache/
 .jekyll-metadata
-Gemfile
-Gemfile.lock
 
 # End of https://www.toptal.com/developers/gitignore/api/jekyll
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:20.04
+RUN apt update
+RUN apt install -y ruby-full
+RUN apt-get install -y build-essential zlib1g-dev
+RUN gem install jekyll bundler
+
+COPY . /usr/src/app
+
+EXPOSE 4000
+RUN ruby --version
+RUN gem --version
+WORKDIR /usr/src/app
+RUN ls /usr/src/app
+RUN bundle install 
+
+CMD ["bundle", "exec", "jekyll", "serve", "--livereload", "--host", "0.0.0.0", "-P", "4000"]

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,36 @@
+source "https://rubygems.org"
+# Hello! This is where you manage which Jekyll version is used to run.
+# When you want to use a different version, change it below, save the
+# file and run `bundle install`. Run Jekyll with `bundle exec`, like so:
+#
+#     bundle exec jekyll serve
+#
+# This will help ensure the proper Jekyll version is running.
+# Happy Jekylling!
+gem "jekyll", "~> 4.2.2"
+# This is the default theme for new Jekyll sites. You may change this to anything you like.
+# change to just the docs
+gem "just-the-docs"
+# If you want to use GitHub Pages, remove the "gem "jekyll"" above and
+# uncomment the line below. To upgrade, run `bundle update github-pages`.
+# gem "github-pages", group: :jekyll_plugins
+# If you have any plugins, put them here!
+group :jekyll_plugins do
+  gem "jekyll-remote-theme"
+end
+
+# Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
+# and associated library.
+platforms :mingw, :x64_mingw, :mswin, :jruby do
+  gem "tzinfo", "~> 1.2"
+  gem "tzinfo-data"
+end
+
+# Performance-booster for watching directories on Windows
+gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
+
+# Lock `http_parser.rb` gem to `v0.6.x` on JRuby builds since newer versions of the gem
+# do not have a Java counterpart.
+gem "http_parser.rb", "~> 0.6.0", :platforms => [:jruby]
+
+gem "webrick", "~> 1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,90 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.1)
+      public_suffix (>= 2.0.2, < 6.0)
+    colorator (1.1.0)
+    concurrent-ruby (1.1.10)
+    em-websocket (0.5.3)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0)
+    eventmachine (1.2.7)
+    ffi (1.15.5)
+    forwardable-extended (2.6.0)
+    http_parser.rb (0.8.0)
+    i18n (1.12.0)
+      concurrent-ruby (~> 1.0)
+    jekyll (4.2.2)
+      addressable (~> 2.4)
+      colorator (~> 1.0)
+      em-websocket (~> 0.5)
+      i18n (~> 1.0)
+      jekyll-sass-converter (~> 2.0)
+      jekyll-watch (~> 2.0)
+      kramdown (~> 2.3)
+      kramdown-parser-gfm (~> 1.0)
+      liquid (~> 4.0)
+      mercenary (~> 0.4.0)
+      pathutil (~> 0.9)
+      rouge (~> 3.0)
+      safe_yaml (~> 1.0)
+      terminal-table (~> 2.0)
+    jekyll-remote-theme (0.4.3)
+      addressable (~> 2.0)
+      jekyll (>= 3.5, < 5.0)
+      jekyll-sass-converter (>= 1.0, <= 3.0.0, != 2.0.0)
+      rubyzip (>= 1.3.0, < 3.0)
+    jekyll-sass-converter (2.2.0)
+      sassc (> 2.0.1, < 3.0)
+    jekyll-seo-tag (2.8.0)
+      jekyll (>= 3.8, < 5.0)
+    jekyll-watch (2.2.1)
+      listen (~> 3.0)
+    just-the-docs (0.3.3)
+      jekyll (>= 3.8.5)
+      jekyll-seo-tag (~> 2.0)
+      rake (>= 12.3.1, < 13.1.0)
+    kramdown (2.4.0)
+      rexml
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    liquid (4.0.3)
+    listen (3.7.1)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    mercenary (0.4.0)
+    pathutil (0.16.2)
+      forwardable-extended (~> 2.6)
+    public_suffix (5.0.0)
+    rake (13.0.6)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.10.1)
+      ffi (~> 1.0)
+    rexml (3.2.5)
+    rouge (3.30.0)
+    rubyzip (2.3.2)
+    safe_yaml (1.0.5)
+    sassc (2.4.0)
+      ffi (~> 1.9)
+    terminal-table (2.0.0)
+      unicode-display_width (~> 1.1, >= 1.1.1)
+    unicode-display_width (1.8.0)
+    webrick (1.7.0)
+
+PLATFORMS
+  ruby
+  x86_64-darwin-20
+  x86_64-linux
+
+DEPENDENCIES
+  http_parser.rb (~> 0.6.0)
+  jekyll (~> 4.2.2)
+  jekyll-remote-theme
+  just-the-docs
+  tzinfo (~> 1.2)
+  tzinfo-data
+  wdm (~> 0.1.1)
+  webrick (~> 1.7)
+
+BUNDLED WITH
+   2.3.7

--- a/README.md
+++ b/README.md
@@ -1,11 +1,18 @@
----
-layout: default
-title: 404
-nav_exclude: true
----
+## Local Testing
 
-# HTAN-data-ingress-documentation-draft
-A draft of the HTAN dataset ingress workflow - to share with tester teams and early adopters.
+### Use Docker
+1. Install Docker and `docker-compose`.
 
-This site is built using the `just-the-docs` jekyll theme and comes with an [excellent set of docs](https://pmarsceill.github.io/just-the-docs/).
+2. Run `docker-compose up` from within repository to launch Jekyll Docker container.
+
+3. Access the local preview of the documentation at http://127.0.0.1:4000.
+
+### Manually install Jekyll 
+1. Follow the documentation [here](https://jekyllrb.com/docs/installation/macos/) to install Ruby 
+2. Check the version of ruby by running `ruby -v`. You version of `ruby` should be 3.1.2 and above
+3. Install Jekyll by running `gem install jekyll`.
+4. (Optional) Follow the quick start instructions [here](https://jekyllrb.com/) on Jekyll's website. You should be able to access the local preview of the documentation at `localhost:4000`
+5. Install `just-the-docs/just-the-docs` and plugin `jekyll-remote-theme` by doing `bundle install` for the first time. (Note: if you change your plugin and remote theme, you might need to run `bundle install again`)
+6. Run `bundle exec jekyll serve`. Then, you should be able to access the local preview of the documentation at http://127.0.0.1:4000.
+
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ### Use Docker
 1. Install Docker and `docker-compose`.
 
-2. Run `docker-compose up` from within repository to launch Jekyll Docker container.
+2. Run `docker compose up -d` from within repository to launch Jekyll Docker container.
 
 3. Access the local preview of the documentation at http://127.0.0.1:4000.
 

--- a/_config.yml
+++ b/_config.yml
@@ -13,5 +13,9 @@ aux_links:
 # Makes Aux links open in a new tab. Default is false
 aux_links_new_tab: true
 
+# Ignore README.md, which is intended for being seen on GitHub
+exclude: 
+  - "README.md"
+
 # allow linking to headers
 heading_anchors: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,10 @@
 version: '3'
 services:
   jekyll:
-    build: .
-    command: sh -c "bundle install && bundle exec jekyll serve --watch --incremental --host 0.0.0.0 --livereload -p 4000:4000"
+    #build: .
+    image: jekyll/jekyll:4.2.2
+    command: jekyll serve --watch --force_polling --verbose
+    #command: sh -c "bundle install && bundle exec jekyll serve --watch --incremental --host 0.0.0.0 --livereload -p 4000:4000"
     ports:
       - "4000:4000"
     working_dir: /usr/src/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3'
+services:
+  jekyll:
+    build: .
+    command: sh -c "bundle install && bundle exec jekyll serve --watch --incremental --host 0.0.0.0 --livereload -p 4000:4000"
+    ports:
+      - "4000:4000"
+    working_dir: /usr/src/app
+    volumes:
+      - ./:/usr/src/app:delegated
+      - site:/usr/src/app/_site
+    tty: true
+
+volumes:
+  site: {}


### PR DESCRIPTION
In addition to changing the content of .md files, I also want to add more contents to help run Jekyll locally. 

We could discuss this after merging Bruno's fork to `gh-page`. 

1. I used Bruno's branch [here](https://github.com/BrunoGrandePhD/HTAN-Data-Ingress-Docs/tree/develop-generic-docs) and tried to run `docker compose up`. But it didn't work. I got an error message: 
```
Attaching to htan-data-ingress-docs-jekyll-1
htan-data-ingress-docs-jekyll-1  | Configuration file: /usr/src/app/_config.yml
htan-data-ingress-docs-jekyll-1  |             Source: /usr/src/app
htan-data-ingress-docs-jekyll-1  |        Destination: /_site
htan-data-ingress-docs-jekyll-1  |  Incremental build: disabled. Enable with --incremental
htan-data-ingress-docs-jekyll-1  |       Generating... 
htan-data-ingress-docs-jekyll-1  | Invalid theme folder: _sass
htan-data-ingress-docs-jekyll-1  |       Remote Theme: Using theme pmarsceill/just-the-docs
htan-data-ingress-docs-jekyll-1  | jekyll 3.8.5 | Error:  404 - Not Found
htan-data-ingress-docs-jekyll-1 exited with code 1

```
At first, I tried to debug by using a different remote theme. For example, the `pmarsceill/just-the-docs` no longer exists, and I changed it to `just-the-docs/just-the-docs` [here](https://github.com/just-the-docs/just-the-docs#:~:text=remote_theme%3A%20just%2Dthe%2Ddocs/just%2Dthe%2Ddocs) But the error message persisted. 

2. I am not sure if that's causing the issue. But `starefossen/github-pages:latest` image used in Bruno's branch also seems to pull an older version of Jekyll. 
3. I then tried out installing Jekyll locally as well as writing a  It is a bit strange that I had to add `bundle-install` command to `docker-compose.yml` even after adding it to `Dockerfile`. But if I don't add that line, I would get an error related to `bundle install`

4. I also tried to pull the official image created by `Jekyll`. Something like this in the `docker-compose.yml`: 
```
version: '3'
services:
  jekyll:
    image: jekyll/jekyll:3.8
    command: sh -c "gem install bundler:2.3.7 && bundle install && bundle exec jekyll serve --watch --incremental --host 0.0.0.0 --livereload -p 4000:4000" 
    ports:
      - "4000:4000"
    working_dir: /usr/src/app
    volumes:
      - ./:/usr/src/app:delegated
      - site:/usr/src/app/_site
    tty: true

volumes:
  site: {}

```

But even by running `docker compose up -d`, the container would exit immediately without showing an error messages.
So in the end, I had to have `docker-compose.yml` calls the Dockerfile to create container.